### PR TITLE
Fix crash when reference doesn't include guid

### DIFF
--- a/src/SlimJim/Infrastructure/CsProjReader.cs
+++ b/src/SlimJim/Infrastructure/CsProjReader.cs
@@ -4,12 +4,15 @@ using System.IO;
 using System.Linq;
 using System.Xml.Linq;
 using SlimJim.Model;
+using log4net;
+using System.Reflection;
 
 namespace SlimJim.Infrastructure
 {
 	public class CsProjReader
 	{
-		private static readonly XNamespace Ns = "http://schemas.microsoft.com/developer/msbuild/2003";
+        private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        private static readonly XNamespace Ns = "http://schemas.microsoft.com/developer/msbuild/2003";
 
 		public virtual CsProj Read(FileInfo csProjFile)
 		{
@@ -26,10 +29,10 @@ namespace SlimJim.Infrastructure
 			{
 				Path = csProjFile.FullName,
 				AssemblyName = assemblyName.Value,
-				Guid = properties.Element(Ns + "ProjectGuid").ValueOrDefault(),
+				Guid = properties.Element(Ns + "ProjectGuid").ValueOrDefault()?.ToUpper(),
 				TargetFrameworkVersion = properties.Element(Ns + "TargetFrameworkVersion").ValueOrDefault(),
 				ReferencedAssemblyNames = ReadReferencedAssemblyNames(xml),
-				ReferencedProjectGuids = ReadReferencedProjectGuids(xml),
+				ReferencedProjectGuids = ReadReferencedProjectGuids(xml, csProjFile),
 				UsesMSBuildPackageRestore = FindImportedNuGetTargets(xml)
 			};
 		}
@@ -60,11 +63,36 @@ namespace SlimJim.Infrastructure
 			return name.Substring(0, name.IndexOf(","));
 		}
 
-		private List<string> ReadReferencedProjectGuids(XElement xml)
+		private List<string> ReadReferencedProjectGuids(XElement xml, FileInfo csprojFile)
 		{
 			return (from pr in xml.DescendantsAndSelf(Ns + "ProjectReference")
-					  select pr.Element(Ns + "Project").Value).ToList();
+					  select ReadProjectGuid(pr, csprojFile)).ToList();
 		}
+
+        private string ReadProjectGuid(XElement projectReference, FileInfo csprojFile)
+        {
+            var project = projectReference.Element(Ns + "Project");
+            if (project == null)
+            {
+                Log.WarnFormat("No project Guid for {0}. Fixing..." , projectReference.Element(Ns + "Name").Value);
+                var filename = projectReference.Attribute("Include")?.Value;
+                if (filename == null)
+                {
+                    Log.WarnFormat("No Include= attribute for project {0}.", projectReference.Element(Ns + "Name").Value);
+                    return null;
+                }
+                filename = Path.Combine(csprojFile.Directory.FullName, filename);
+                var projectFile = LoadXml(new FileInfo(filename));
+                var projectGuid = projectFile?.Element(Ns + "PropertyGroup")?.Element(Ns + "ProjectGuid");
+                if (projectGuid == null)
+                {
+                    Log.WarnFormat("ProjectGuid not found in {0}", filename);
+                    return null;
+                }
+                return projectGuid.Value.ToUpper();
+            }
+            return project.Value.ToUpper();
+        }
 
 		private bool FindImportedNuGetTargets(XElement xml)
 		{


### PR DESCRIPTION
Issue #9

This reads the Guid from the referenced project file
when it's missing from the referencing project file.
