### PR TITLE
Fix Guid Case Mismatch

### DIFF
--- a/src/SlimJim/Infrastructure/CsProjReader.cs
+++ b/src/SlimJim/Infrastructure/CsProjReader.cs
@@ -26,7 +26,7 @@ namespace SlimJim.Infrastructure
 			{
 				Path = csProjFile.FullName,
 				AssemblyName = assemblyName.Value,
-				Guid = properties.Element(Ns + "ProjectGuid").ValueOrDefault(),
+				Guid = properties.Element(Ns + "ProjectGuid").ValueOrDefault()?.ToUpper(),
 				TargetFrameworkVersion = properties.Element(Ns + "TargetFrameworkVersion").ValueOrDefault(),
 				ReferencedAssemblyNames = ReadReferencedAssemblyNames(xml),
 				ReferencedProjectGuids = ReadReferencedProjectGuids(xml),
@@ -63,7 +63,7 @@ namespace SlimJim.Infrastructure
 		private List<string> ReadReferencedProjectGuids(XElement xml)
 		{
 			return (from pr in xml.DescendantsAndSelf(Ns + "ProjectReference")
-					  select pr.Element(Ns + "Project").Value).ToList();
+					  select pr.Element(Ns + "Project").Value?.ToUpper()).ToList();
 		}
 
 		private bool FindImportedNuGetTargets(XElement xml)


### PR DESCRIPTION
Visual Studio uses lowercase Guids in the ProjectReferences tag
and uppercase in the ProjectGuid tag. This change upcases the
Guids when loading projects to the case in consistent and project
Guids match correctly. Issue #6
