### PR TITLE
Add -minimal option to skip afferent references

### DIFF
--- a/src/SlimJim/Infrastructure/ArgsOptionsBuilder.cs
+++ b/src/SlimJim/Infrastructure/ArgsOptionsBuilder.cs
@@ -46,6 +46,8 @@ namespace SlimJim.Infrastructure
 									v => options.VisualStudioVersion = TryParseVersionNumber(v) },
 								{ "n|name=", "alternate {NAME} for solution file", 
 									v => options.SolutionName = v},
+								{ "m|minimal", "skip all afferent assembly references (included by default)",
+									v => options.SkipAfferentAssemblyReferences = true },
 								{ "a|all", "include all efferent assembly references (omitted by default)", 
 									v => options.IncludeEfferentAssemblyReferences = true },
 								{ "h|help", "display the help screen", 

--- a/src/SlimJim/Model/SlnBuilder.cs
+++ b/src/SlimJim/Model/SlnBuilder.cs
@@ -58,7 +58,10 @@ namespace SlimJim.Model
 					Log.WarnFormat("Project {0} not found.", targetProjectName);
 				}
 
-				AddAfferentReferencesToProject(rootProject);
+				if (options.SkipAfferentAssemblyReferences == false)
+				{
+					AddAfferentReferencesToProject(rootProject);
+				}
 			}
 		}
 

--- a/src/SlimJim/Model/SlnGenerationOptions.cs
+++ b/src/SlimJim/Model/SlnGenerationOptions.cs
@@ -38,6 +38,7 @@ namespace SlimJim.Model
 		}
 
 		public VisualStudioVersion VisualStudioVersion { get; set; }
+		public bool SkipAfferentAssemblyReferences { get; set; }
 		public bool IncludeEfferentAssemblyReferences { get; set; }
 		public bool ShowHelp { get; set; }
 		public bool ConvertReferences { get; set; }


### PR DESCRIPTION
It is sometimes useful to create a .sln file with only the
efferent references. This makes the solution smaller.
This change adds this as an option. Leaving the current
behavior as the default.
